### PR TITLE
config-dialog-functions.sqf v0.1

### DIFF
--- a/DCW/config/config-dialog-functions.sqf
+++ b/DCW/config/config-dialog-functions.sqf
@@ -263,7 +263,7 @@ DCW_fnc_saveAndCloseConfigDialog = {
 			
 		sleep .5;
 
-		titleCut ["Configuring units...", "BLACK FADED", 999];
+		titleCut [localize "STR_DCW_configDialogFunctions_preparing", "BLACK FADED", 999];
 
 		// Execute mission setup on server
 		[] remoteExec ["DCW_fnc_missionSetup", 2];


### PR DESCRIPTION
Juste un petit changement qui permet d'avoir le texte, configuré juste au dessus par tes soins, réellement actif. Sinon la traduction ne prend pas effet. Résolu.