### PR TITLE
missionParameters.hpp

### DIFF
--- a/DCW/config/missionParameters.hpp
+++ b/DCW/config/missionParameters.hpp
@@ -3,48 +3,48 @@ class Params
 	
 	class AISkill
 	{
-		title = "AI Skill"; // Param name visible in the list
+		title = $STR_DCW_missionParameters_AiSkill; // Param name visible in the list
 		values[] = {0,1,2}; // Values; must be integers; has to have the same number of elements as 'texts'
-		texts[] = {"Recruit","Regular","Veteran (Recommended)"}; // Description of each selectable item
+		texts[] = {$STR_DCW_missionParameters_recruit,$STR_DCW_missionParameters_regular,$STR_DCW_missionParameters_veteran}; // Description of each selectable item
 		default = 2; // Default value; must be listed in 'values' array, otherwise 0 is used
 	};
 	class Debug
 	{
-		title = "Debug";
-		texts[] = {"Yes","No"};
+		title = $STR_DCW_missionParameters_debug;
+		texts[] = {$STR_DCW_missionParameters_yes,$STR_DCW_missionParameters_no};
 		values[] = {1,0};
 		default = 0;
 		isGlobal = 1; 
 	};
 	class Respawn
 	{
-		title = "Respawn";
-		texts[] = {"Yes (default)","No"};
+		title = $STR_DCW_missionParameters_respawn;
+		texts[] = $STR_DCW_missionParameters_yesdefault,$STR_DCW_missionParameters_no};
 		values[] = {1,0};
 		default = 1;
 		isGlobal = 1; 
 	};
 	class Reviving
 	{
-		title = "Reviving (With medevac module that replaces dead AI)";
-		texts[] = {"Yes (default)","No"};
+		title = $STR_DCW_missionParameters_reviving;
+		texts[] = {$STR_DCW_missionParameters_yesdefault,$STR_DCW_missionParameters_no};
 		values[] = {1,0};
 		default = 1;
 		isGlobal = 1; 
 	};
 	class NumberRespawn
 	{
-		title = "Number of respawn";
-		texts[] = {"1","4 (default)","Unlimited"};
-		values[] = {1,4,9999};
+		title = $STR_DCW_missionParameters_numberRespawn;
+		texts[] = {"1","2",$STR_DCW_missionParameters_4default,"5","10",$STR_DCW_missionParameters_unlimited};
+		values[] = {1,2,4,5,10,9999};
 		default = 4;
 		isGlobal = 0; 
 	};
 	class Daytime
 	{
-		title = "Time";
-		texts[] = {"Morning","Day (default)","Evening","Night"};
-		values[] = {6,12,18,0};
+		title = $STR_DCW_missionParameters_time;
+		texts[] = {$STR_DCW_missionParameters_earlyMorning,$STR_DCW_missionParameters_sunRise,$STR_DCW_missionParameters_morning,$STR_DCW_missionParameters_morningAdvanced,$STR_DCW_missionParameters_noon,$STR_DCW_missionParameters_startAfternoon,$STR_DCW_missionParameters_afternoon,$STR_DCW_missionParameters_endAfternoon,$STR_DCW_missionParameters_sunset,$STR_DCW_missionParameters_evening,$STR_DCW_missionParameters_midnight,$STR_DCW_missionParameters_darknight};
+		values[] = {4,6,8,10,12,14,16,18,20,22,0,2};
 		default = 12;
 		function = "BIS_fnc_paramDaytime"; // (Optional) [[Functions_Library_(Arma_3)|Function]] [[call]]ed when player joins, selected value is passed as an argument
 		isGlobal = 1; // (Optional) 1 to execute script / function locally for every player who joins, 0 to do it only on server


### PR DESCRIPTION
Mise en place du STR sur la config. Attention peut être problème avec les localize. A vérifier.
Le "configuring unit" n'était pas doublé. il ne s'affichait donc pas correctement en jeu. Avec le doublon le problème devrait être corrigé.