### PR TITLE
Update fn_deleteMedevac.sqf

### DIFF
--- a/DCW/functions/Medical/fn_deleteMedevac.sqf
+++ b/DCW/functions/Medical/fn_deleteMedevac.sqf
@@ -3,7 +3,7 @@
     Bidass
 
   Version:
-    {VERSION}
+    0.9.1
 
   Description:
     TODO
@@ -22,4 +22,9 @@ if(!isNull _helo)then{
 	{ deleteVehicle _x ;} forEach units interventionGroup;
 	{ deleteVehicle _x ;} forEach crew _helo;
 	deleteVehicle _helo;
+	
+sleep 5;
+	
+[HQ,localize "STR_DCW_voices_HQ_rtb",true] remoteExec ["DCW_fnc_talk"];
+
 };


### PR DESCRIPTION
Add:

-ligne de conversation HQ. En temps normal le C.O (Centre Opérationel) tentera toujours de tenir informé leurs hommes sur le terrain. Annoncer qu'un hélico est bien rentré à la base à plusieurs sens.
Le premier peut en effet servir à rassurer (en cas de MEDEVAC). Pour dire "ok, le blessé va être pris en charge".
Le deuxième est aussi pour avertir que ce même hélicoptère va bientôt pouvoir repartir en cas de pépins.